### PR TITLE
Allow users to use 'c' to control the Fishing Game

### DIFF
--- a/src/Components/FishingGame.js
+++ b/src/Components/FishingGame.js
@@ -42,12 +42,20 @@ function Game(props){
         document.addEventListener("mouseup", handleMouseUp);
         document.addEventListener("touchstart", handleMouseDown);
         document.addEventListener("touchend", handleMouseUp);
+        document.addEventListener("keydown", (event) => {
+            if (event.key === 'c') handleMouseDown()
+        })
+        document.addEventListener("keyup", (event) => {
+            if (event.key === 'c') handleMouseUp()
+        })
         
         return () => {
             document.removeEventListener("mousedown", handleMouseDown);
             document.removeEventListener("mouseup", handleMouseUp);
             document.removeEventListener("touchstart", handleMouseDown);
             document.removeEventListener("touchend", handleMouseUp);
+            document.removeEventListener("keydown", handleMouseDown);
+            document.removeEventListener("keyup", handleMouseUp);
         }
     }, [])
 


### PR DESCRIPTION
Some users have found that in Stardew Valley they prefer to use `c` to control the fishing minigame, in this PR I added it to the fishing minigame here.